### PR TITLE
Stale modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Options:
     	hex-encoded pre-shared key. Can be generated with genpsk subcommand
   -skip-hello-verify
     	(server only) skip hello verify request. Useful to workaround DPI
+  -stale-mode value
+    	which stale side of connection makes whole session stale (both, either, left, right) (default either)
   -timeout duration
     	network operation timeout (default 10s)
 ```

--- a/client/client.go
+++ b/client/client.go
@@ -27,6 +27,7 @@ type Client struct {
 	idleTimeout time.Duration
 	baseCtx     context.Context
 	cancelCtx   func()
+	staleMode   util.StaleMode
 }
 
 func New(cfg *Config) (*Client, error) {
@@ -41,6 +42,7 @@ func New(cfg *Config) (*Client, error) {
 		idleTimeout: cfg.IdleTimeout,
 		baseCtx:     baseCtx,
 		cancelCtx:   cancelCtx,
+		staleMode:   cfg.StaleMode,
 	}
 
 	lAddrPort, err := netip.ParseAddrPort(cfg.BindAddress)
@@ -110,7 +112,7 @@ func (client *Client) serve(conn net.Conn) {
 		return
 	}
 
-	util.PairConn(conn, remoteConn, client.idleTimeout)
+	util.PairConn(conn, remoteConn, client.idleTimeout, client.staleMode)
 }
 
 func (client *Client) contextMaker() (context.Context, func()) {

--- a/client/config.go
+++ b/client/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/Snawoot/dtlspipe/ciphers"
+	"github.com/Snawoot/dtlspipe/util"
 )
 
 type Config struct {
@@ -18,6 +19,7 @@ type Config struct {
 	MTU            int
 	CipherSuites   ciphers.CipherList
 	EllipticCurves ciphers.CurveList
+	StaleMode      util.StaleMode
 }
 
 func (cfg *Config) populateDefaults() *Config {

--- a/cmd/dtlspipe/main.go
+++ b/cmd/dtlspipe/main.go
@@ -71,11 +71,13 @@ var (
 	skipHelloVerify = flag.Bool("skip-hello-verify", false, "(server only) skip hello verify request. Useful to workaround DPI")
 	ciphersuites    = cipherlistArg{}
 	curves          = curvelistArg{}
+	staleMode       = util.EitherStale
 )
 
 func init() {
 	flag.Var(&ciphersuites, "ciphers", "colon-separated list of ciphers to use")
 	flag.Var(&curves, "curves", "colon-separated list of curves to use")
+	flag.Var(&staleMode, "stale-mode", "which stale side of connection makes whole session stale")
 }
 
 func usage() {
@@ -136,6 +138,7 @@ func cmdClient(bindAddress, remoteAddress string) int {
 		MTU:            *mtu,
 		CipherSuites:   ciphersuites.Value,
 		EllipticCurves: curves.Value,
+		StaleMode:      staleMode,
 	}
 
 	clt, err := client.New(&cfg)
@@ -172,6 +175,7 @@ func cmdServer(bindAddress, remoteAddress string) int {
 		SkipHelloVerify: *skipHelloVerify,
 		CipherSuites:    ciphersuites.Value,
 		EllipticCurves:  curves.Value,
+		StaleMode:       staleMode,
 	}
 
 	srv, err := server.New(&cfg)

--- a/cmd/dtlspipe/main.go
+++ b/cmd/dtlspipe/main.go
@@ -77,7 +77,7 @@ var (
 func init() {
 	flag.Var(&ciphersuites, "ciphers", "colon-separated list of ciphers to use")
 	flag.Var(&curves, "curves", "colon-separated list of curves to use")
-	flag.Var(&staleMode, "stale-mode", "which stale side of connection makes whole session stale")
+	flag.Var(&staleMode, "stale-mode", "which stale side of connection makes whole session stale (both, either, left, right)")
 }
 
 func usage() {

--- a/cmd/dtlspipe/main.go
+++ b/cmd/dtlspipe/main.go
@@ -62,7 +62,7 @@ var (
 	version = "undefined"
 
 	timeout         = flag.Duration("timeout", 10*time.Second, "network operation timeout")
-	idleTime        = flag.Duration("idle-time", 90*time.Second, "max idle time for UDP session")
+	idleTime        = flag.Duration("idle-time", 30*time.Second, "max idle time for UDP session")
 	pskHexOpt       = flag.String("psk", "", "hex-encoded pre-shared key. Can be generated with genpsk subcommand")
 	keyLength       = flag.Uint("key-length", 16, "generate key with specified length")
 	identity        = flag.String("identity", "", "client identity sent to server")

--- a/server/config.go
+++ b/server/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/Snawoot/dtlspipe/ciphers"
+	"github.com/Snawoot/dtlspipe/util"
 )
 
 type Config struct {
@@ -18,6 +19,7 @@ type Config struct {
 	SkipHelloVerify bool
 	CipherSuites    ciphers.CipherList
 	EllipticCurves  ciphers.CurveList
+	StaleMode       util.StaleMode
 }
 
 func (cfg *Config) populateDefaults() *Config {

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ type Server struct {
 	idleTimeout time.Duration
 	baseCtx     context.Context
 	cancelCtx   func()
+	staleMode   util.StaleMode
 }
 
 func New(cfg *Config) (*Server, error) {
@@ -42,6 +43,7 @@ func New(cfg *Config) (*Server, error) {
 		idleTimeout: cfg.IdleTimeout,
 		baseCtx:     baseCtx,
 		cancelCtx:   cancelCtx,
+		staleMode:   cfg.StaleMode,
 	}
 
 	lAddrPort, err := netip.ParseAddrPort(cfg.BindAddress)
@@ -122,7 +124,7 @@ func (srv *Server) serve(conn net.Conn) {
 	}
 	defer remoteConn.Close()
 
-	util.PairConn(conn, remoteConn, srv.idleTimeout)
+	util.PairConn(conn, remoteConn, srv.idleTimeout, srv.staleMode)
 }
 
 func (srv *Server) contextMaker() (context.Context, func()) {

--- a/util/tracker.go
+++ b/util/tracker.go
@@ -1,0 +1,70 @@
+package util
+
+import "sync/atomic"
+
+type StaleMode int
+
+const (
+	BothStale = iota
+	EitherStale
+	LeftStale
+	RightStale
+)
+
+type tracker struct {
+	leftCounter     atomic.Int32
+	rightCounter    atomic.Int32
+	leftTimedOutAt  atomic.Int32
+	rightTimedOutAt atomic.Int32
+	staleFun        func() bool
+}
+
+func newTracker(staleMode StaleMode) *tracker {
+	t := &tracker{}
+	switch staleMode {
+	case BothStale:
+		t.staleFun = t.bothStale
+	case EitherStale:
+		t.staleFun = t.eitherStale
+	case LeftStale:
+		t.staleFun = t.leftStale
+	case RightStale:
+		t.staleFun = t.rightStale
+	default:
+		panic("unsupported stale mode")
+	}
+	return t
+}
+
+func (t *tracker) notify(isLeft bool) {
+	if isLeft {
+		t.leftCounter.Add(1)
+	} else {
+		t.rightCounter.Add(1)
+	}
+}
+
+func (t *tracker) handleTimeout(isLeft bool) bool {
+	if isLeft {
+		t.leftTimedOutAt.Store(t.leftCounter.Load())
+	} else {
+		t.rightTimedOutAt.Store(t.rightCounter.Load())
+	}
+	return t.staleFun()
+}
+
+func (t *tracker) leftStale() bool {
+	return t.leftCounter.Load() == t.leftTimedOutAt.Load()
+}
+
+func (t *tracker) rightStale() bool {
+	return t.rightCounter.Load() == t.rightTimedOutAt.Load()
+}
+
+func (t *tracker) bothStale() bool {
+	return t.leftStale() && t.rightStale()
+}
+
+func (t *tracker) eitherStale() bool {
+	return t.leftStale() || t.rightStale()
+}


### PR DESCRIPTION
Introduces new option `-stale-mode` and additional modes of detection of stale connection:

* `both` - old mode, connection is closed as stale when both sides do not produce read events
* `either` - new default mode, connection is closed as stale when either side does not produce read events
* `left` - connection is closed as stale when *accepted* (initiated by peer) UDP session does not produce read events
* `right` - connection is closed as stale when *dialed* (initiated by dtlspipe) UDP session does not produce read events

Also changes default idle timeout to 30 seconds.