### PR TITLE
Session hard time limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Options:
   -identity string
     	client identity sent to server
   -idle-time duration
-    	max idle time for UDP session (default 1m30s)
+    	max idle time for UDP session (default 30s)
   -key-length uint
     	generate key with specified length (default 16)
   -mtu int
@@ -91,6 +91,8 @@ Options:
     	(server only) skip hello verify request. Useful to workaround DPI
   -stale-mode value
     	which stale side of connection makes whole session stale (both, either, left, right) (default either)
+  -time-limit duration
+    	hard time limit for each session
   -timeout duration
     	network operation timeout (default 10s)
 ```

--- a/client/config.go
+++ b/client/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	CipherSuites   ciphers.CipherList
 	EllipticCurves ciphers.CurveList
 	StaleMode      util.StaleMode
+	TimeLimit      time.Duration
 }
 
 func (cfg *Config) populateDefaults() *Config {

--- a/cmd/dtlspipe/main.go
+++ b/cmd/dtlspipe/main.go
@@ -72,6 +72,7 @@ var (
 	ciphersuites    = cipherlistArg{}
 	curves          = curvelistArg{}
 	staleMode       = util.EitherStale
+	timeLimit       = flag.Duration("time-limit", 0, "hard time limit for each session")
 )
 
 func init() {
@@ -139,6 +140,7 @@ func cmdClient(bindAddress, remoteAddress string) int {
 		CipherSuites:   ciphersuites.Value,
 		EllipticCurves: curves.Value,
 		StaleMode:      staleMode,
+		TimeLimit:      *timeLimit,
 	}
 
 	clt, err := client.New(&cfg)
@@ -176,6 +178,7 @@ func cmdServer(bindAddress, remoteAddress string) int {
 		CipherSuites:    ciphersuites.Value,
 		EllipticCurves:  curves.Value,
 		StaleMode:       staleMode,
+		TimeLimit:       *timeLimit,
 	}
 
 	srv, err := server.New(&cfg)

--- a/server/config.go
+++ b/server/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	CipherSuites    ciphers.CipherList
 	EllipticCurves  ciphers.CurveList
 	StaleMode       util.StaleMode
+	TimeLimit       time.Duration
 }
 
 func (cfg *Config) populateDefaults() *Config {


### PR DESCRIPTION
It's an attempt to prevent ban by DPI due to long DTLS sessions as described here: https://twitter.com/SAPikachu/status/611428615377559552

The idea is to proactively re-establish DTLS session before it gets attention of DPI system. Implementation just cuts connection after a while, new connection will be triggered again if there is still traffic going on.